### PR TITLE
Add runnable Fast Sim examples for common scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ fsim sweep sim/config.yaml --out runs/ --runs 3
 fsim summarize runs/ --metric population
 ```
 
+## Full examples
+
+The repository ships runnable scripts for the most common simulation
+scenarios under [`examples/`](examples/):
+
+* `examples/seir_epidemic.py` – step-based SEIR epidemic with metrics
+* `examples/mm1_queue.py` – discrete-event M/M/1 queue and utilisation
+  tracking
+* `examples/traffic_cellular_automata.py` – cellular automaton traffic
+  model measuring flow and density
+
+Execute them with `python examples/<file>.py` to see end-to-end Fast Sim
+workflows and use the exposed `simulate_*` functions as templates for
+your own models.
+
 ## Reproducibility
 
 Randomness is handled by `fast_sim.core.RNG`, a deterministic wrapper over

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Fast Sim Examples
+
+The `examples/` directory contains runnable scripts that showcase the most common workflows for Fast Sim users. Each script can be executed with plain Python and demonstrates how to configure state, run the engines, and capture simple metrics for later analysis.
+
+## Available examples
+
+| File | Scenario | Highlights |
+| --- | --- | --- |
+| [`seir_epidemic.py`](seir_epidemic.py) | Compartmental epidemic model | Uses `StepEngine`, tracks compartment counts, reports infection peak. |
+| [`mm1_queue.py`](mm1_queue.py) | M/M/1 queue with exponential arrivals/services | Uses `EventEngine`, records utilisation and throughput. |
+| [`traffic_cellular_automata.py`](traffic_cellular_automata.py) | Single-lane traffic cellular automaton | Uses `StepEngine`, measures average speed and density. |
+
+## Running an example
+
+```bash
+python examples/seir_epidemic.py
+python examples/mm1_queue.py
+python examples/traffic_cellular_automata.py
+```
+
+Each script exposes a `simulate_*` function that can be imported into notebooks or test suites when you want to customise parameters or embed the simulations in larger experiments.
+
+All examples rely only on the public Fast Sim API and therefore double as templates for building your own models.

--- a/examples/mm1_queue.py
+++ b/examples/mm1_queue.py
@@ -1,0 +1,81 @@
+"""Full M/M/1 queue discrete-event simulation example.
+
+The example models a single-server queue with exponential inter-arrivals
+and service times.  It demonstrates how to drive the
+:class:`fast_sim.EventEngine`, collect queue length statistics, and run
+what-if scenarios by tweaking arrival or service rates.
+
+Execute directly from the project root:
+
+.. code-block:: bash
+
+    python examples/mm1_queue.py
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fast_sim import EventEngine, Metrics, RNG, State
+from fast_sim.core.event_queue import Event, EventQueue
+from fast_sim.examples.mm1_queue import ARRIVAL, mm1_event_handler
+
+
+@dataclass
+class QueueResult:
+    """Result bundle for :func:`simulate_mm1`."""
+
+    state: State
+    metrics: Metrics
+    events_processed: int
+
+
+def simulate_mm1(
+    *,
+    arrival_rate: float = 0.85,
+    service_rate: float = 1.0,
+    until: float = 200.0,
+    seed: int = 42,
+) -> QueueResult:
+    """Run an M/M/1 queue simulation."""
+
+    state = State(1)
+    state.add_field("queue_length", int, 0)
+    state.add_field("busy", int, 0)
+    state.add_field("arrivals", int, 0)
+    state.add_field("departures", int, 0)
+    state.add_field("arrival_rate", float, arrival_rate)
+    state.add_field("service_rate", float, service_rate)
+
+    rng = RNG(seed)
+    metrics = Metrics()
+
+    def handler(state: State, rng: RNG, t: float, queue: EventQueue, event: Event) -> None:
+        mm1_event_handler(state, rng, t, queue, event)
+        metrics.observe("queue_length", float(state["queue_length"][0]), t)
+        metrics.observe("busy", float(state["busy"][0]), t)
+        metrics.observe("arrivals", float(state["arrivals"][0]), t)
+        metrics.observe("departures", float(state["departures"][0]), t)
+
+    engine = EventEngine(state, start_time=0.0, rng=rng, handle_event_fn=handler, metrics=metrics)
+    engine.schedule(time=0.0, kind=ARRIVAL)
+    summary = engine.run(until=until, progress=False)
+    return QueueResult(state=state, metrics=metrics, events_processed=summary.events)
+
+
+def main() -> None:
+    result = simulate_mm1()
+    final_queue = int(result.state["queue_length"][0])
+    utilisation = result.metrics.rate("busy", window=10.0)
+    total_arrivals = int(result.state["arrivals"][0])
+    total_departures = int(result.state["departures"][0])
+
+    print("Queue statistics after the run:")
+    print(f"  Events processed : {result.events_processed}")
+    print(f"  Queue length     : {final_queue}")
+    print(f"  Utilisation (≈)  : {utilisation:.2f}")
+    print(f"  Arrivals         : {total_arrivals}")
+    print(f"  Departures       : {total_departures}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/seir_epidemic.py
+++ b/examples/seir_epidemic.py
@@ -1,0 +1,94 @@
+"""Full SEIR epidemic simulation example.
+
+This example demonstrates how to build a classic compartmental
+susceptible-exposed-infectious-recovered (SEIR) model using the
+:class:`fast_sim.StepEngine`.  It shows how to set up the simulation
+state, advance it over time, and collect simple metrics that can later be
+analysed or plotted.
+
+Run it directly to execute the simulation and print a small summary:
+
+.. code-block:: bash
+
+    python examples/seir_epidemic.py
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+from fast_sim import Metrics, RNG, State, StepEngine, Timeline
+from fast_sim.examples.seir_epidemic import (
+    EXPOSED,
+    INFECTIOUS,
+    RECOVERED,
+    SUSCEPTIBLE,
+    seir_tick,
+)
+
+
+@dataclass
+class SeirResult:
+    """Container returned by :func:`simulate_seir`."""
+
+    state: State
+    metrics: Metrics
+    summary: dict[str, int]
+
+
+def simulate_seir(
+    *,
+    population: int = 200,
+    beta: float = 0.25,
+    sigma: float = 0.2,
+    gamma: float = 0.1,
+    days: float = 120.0,
+    seed: int = 123,
+) -> SeirResult:
+    """Run an SEIR simulation and collect summary metrics."""
+
+    state = State(population)
+    state.add_field("status", int, [SUSCEPTIBLE] * (population - 5) + [INFECTIOUS] * 5)
+    state.add_field("beta", float, beta)
+    state.add_field("sigma", float, sigma)
+    state.add_field("gamma", float, gamma)
+
+    rng = RNG(seed)
+    timeline = Timeline(t0=0.0, dt=1.0, horizon=days)
+    metrics = Metrics()
+
+    def tick(state: State, rng: RNG, t: float) -> None:
+        seir_tick(state, rng, t)
+        counts = Counter(state["status"])
+        metrics.observe("susceptible", float(counts.get(SUSCEPTIBLE, 0)), t)
+        metrics.observe("exposed", float(counts.get(EXPOSED, 0)), t)
+        metrics.observe("infectious", float(counts.get(INFECTIOUS, 0)), t)
+        metrics.observe("recovered", float(counts.get(RECOVERED, 0)), t)
+
+    engine = StepEngine(state, timeline, rng, tick, metrics=metrics)
+    engine.run(progress=False)
+
+    final_counts = Counter(state["status"])
+    summary = {
+        "susceptible": final_counts.get(SUSCEPTIBLE, 0),
+        "exposed": final_counts.get(EXPOSED, 0),
+        "infectious": final_counts.get(INFECTIOUS, 0),
+        "recovered": final_counts.get(RECOVERED, 0),
+    }
+    return SeirResult(state=state, metrics=metrics, summary=summary)
+
+
+def main() -> None:
+    result = simulate_seir()
+    print("Final compartment sizes:")
+    for name, value in result.summary.items():
+        print(f"  {name.title():<12}: {value}")
+
+    infectious_series = result.metrics.series.get("infectious", [])
+    if infectious_series:
+        peak_time, peak_value = max(infectious_series, key=lambda entry: entry[1])
+        print(f"\nPeak infectious count: {int(peak_value)} on day {peak_time:.0f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/traffic_cellular_automata.py
+++ b/examples/traffic_cellular_automata.py
@@ -1,0 +1,93 @@
+"""Traffic cellular automaton simulation example.
+
+This script configures a single-lane ring road where cars follow the
+Nagel–Schreckenberg rules.  It illustrates how to model agent-based
+systems with the :class:`fast_sim.StepEngine` and capture throughput
+metrics at every step.
+
+Run directly with:
+
+.. code-block:: bash
+
+    python examples/traffic_cellular_automata.py
+"""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from fast_sim import Metrics, RNG, State, StepEngine, Timeline
+from fast_sim.examples.traffic_ca import traffic_tick
+
+
+@dataclass
+class TrafficResult:
+    """Return type for :func:`simulate_traffic`."""
+
+    state: State
+    metrics: Metrics
+    steps: int
+
+
+def simulate_traffic(
+    *,
+    length: int = 60,
+    density: float = 0.35,
+    vmax: int = 5,
+    slow_prob: float = 0.25,
+    steps: int = 200,
+    seed: int = 999,
+) -> TrafficResult:
+    """Simulate a cellular-automaton traffic model."""
+
+    cars = int(length * density)
+    road = [-1 for _ in range(length)]
+    for idx in range(cars):
+        road[idx] = idx
+    random.Random(seed).shuffle(road)
+    velocity = [0 for _ in range(length)]
+
+    state = State(length)
+    state.add_field("road", int, road)
+    state.add_field("velocity", int, velocity)
+    state.add_field("vmax", int, vmax)
+    state.add_field("slow_prob", float, slow_prob)
+
+    rng = RNG(seed)
+    timeline = Timeline(t0=0.0, dt=1.0, horizon=float(steps))
+    metrics = Metrics()
+
+    def tick(state: State, rng: RNG, t: float) -> None:
+        traffic_tick(state, rng, t)
+        occupied = [idx for idx, cell in enumerate(state["road"]) if cell >= 0]
+        if not occupied:
+            return
+        total_speed = sum(state["velocity"][idx] for idx in occupied)
+        avg_speed = total_speed / len(occupied)
+        metrics.observe("avg_speed", float(avg_speed), t)
+        metrics.observe("density", float(len(occupied)) / len(state["road"]), t)
+
+    engine = StepEngine(state, timeline, rng, tick, metrics=metrics)
+    summary = engine.run(progress=False)
+    return TrafficResult(state=state, metrics=metrics, steps=summary.steps)
+
+
+def main() -> None:
+    result = simulate_traffic()
+    avg_speed_series = result.metrics.series.get("avg_speed", [])
+    if avg_speed_series:
+        last_speed = avg_speed_series[-1][1]
+        overall_avg = sum(speed for _, speed in avg_speed_series) / len(avg_speed_series)
+    else:
+        last_speed = 0.0
+        overall_avg = 0.0
+
+    print("Traffic summary:")
+    print(f"  Steps simulated : {result.steps}")
+    print(f"  Cars on road    : {sum(1 for cell in result.state['road'] if cell >= 0)}")
+    print(f"  Last avg speed  : {last_speed:.2f}")
+    print(f"  Mean avg speed  : {overall_avg:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add runnable scripts under examples/ for SEIR epidemics, M/M/1 queues, and traffic cellular automata using the public API
- document the new examples in README.md with guidance on how to execute them

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfb36ca940833199e79e65521b11d7