### PR TITLE
Prepare fast-sim 0.1.0 release scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
-
 on:
   push:
-    branches: ["main", "master"]
   pull_request:
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,23 +10,16 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[dev,bench]'
+          pip install -e ".[dev,bench,viz]"
       - name: Lint
         run: ruff check .
       - name: Type check
         run: mypy src/fast_sim --ignore-missing-imports
-      - name: Run tests
-        run: pytest -q --cov=fast_sim --cov-report=xml
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ matrix.python-version }}
-          path: coverage.xml
-          if-no-files-found: ignore
+      - name: Tests
+        run: pytest -q

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 init:
-	pip install -e '.[dev,bench]'
+	pip install -e ".[dev,bench,viz]"
 
 test:
 	pytest -q
@@ -11,10 +11,10 @@ type:
 	mypy src/fast_sim --ignore-missing-imports
 
 examples:
-	python examples/sir_minimal.py
+	fsim run --config examples/configs/sir_demo.yaml --steps 10 --seed 123
 
 bench:
-	fastsim bench --quick
+	fsim bench --quick
 
 dist:
 	python -m build

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 Vectorised micro and discrete-event simulation with deterministic RNG and batteries-included experiment tooling.
 
-[![CI](https://github.com/simonv3/fast-sim/actions/workflows/ci.yml/badge.svg)](https://github.com/simonv3/fast-sim/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/fast-sim.svg?label=PyPI)](https://pypi.org/project/fast-sim/)
-![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)
-![License](https://img.shields.io/badge/license-MIT-green.svg)
+[![CI](https://github.com/mmprotest/fast-sim/actions/workflows/ci.yml/badge.svg)](https://github.com/mmprotest/fast-sim/actions/workflows/ci.yml)
+![Python](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12-blue)
+![License](https://img.shields.io/badge/license-MIT-green)
 
 ## 90-second quickstart
+
+> Note on name collisions  
+> There is an unrelated project called **fastsim** on PyPI. This package is published as **fast-sim**. Until the first PyPI release is live, use the editable install below.
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e '.[dev,bench]'
-fastsim info
-fastsim run --config examples/configs/sir_demo.yaml --steps 50 --seed 123
+pip install -e ".[dev,bench,viz]"
+fsim info
+fsim run --config examples/configs/sir_demo.yaml --steps 50 --seed 123
 ```
 
 Expected first lines of output:
@@ -58,10 +60,21 @@ print(metrics["I"].max())
 Run the benchmark harness (fast, deterministic):
 
 ```bash
-fastsim bench --quick
+fsim bench --quick
 ```
 
 Install optional extras to compare with `simpy` and `mesa`. Missing adapters are reported without failing.
+
+### How this differs from SimPy / Mesa
+| Aspect | fast-sim | SimPy | Mesa |
+|---|---|---|---|
+| State model | Vectorised NumPy arrays | Process/yield model | Object-per-agent |
+| Determinism | Central RNG with seed, stable outputs | Deterministic when carefully seeded | Deterministic with care |
+| Batteries included | CLI, sweeps, metrics, tiny benchmarks | Library focused | Framework focused |
+| Footprint | Minimal core deps | Minimal | Heavier (framework) |
+
+### Release status
+Targeting v0.1.0. Until PyPI is live, please use the editable install. See `RELEASE_NOTES.md`.
 
 ## Roadmap
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,9 @@
+# fast-sim Releases
+
+## v0.1.0
+- Editable install flow until PyPI publish
+- Deterministic RNG surfaced and documented
+- Consistent CLI (`fsim`) with `info`, `run`, `bench`
+- Examples: SIR minimal and queue demo
+- Minimal CI across 3.10–3.12 with lint and type checks
+- README badges, name-collision note, and SimPy/Mesa comparison table

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,7 +3,7 @@
 The benchmark harness exercises the built-in SIR and queue scenarios at two sizes. Run it via the CLI:
 
 ```bash
-fastsim bench --quick
+fsim bench --quick
 ```
 
 The harness prints a Markdown table comparing fast-sim against optional adapters for `simpy` and `mesa`. If those packages are unavailable, the table includes "adapter not available" rows and continues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,55 +1,57 @@
 [build-system]
-requires = ["hatchling>=1.18"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
 name = "fast-sim"
 dynamic = ["version"]
-description = "Vectorised micro and discrete-event simulation with deterministic RNG and experiment tooling."
+description = "Vectorised micro/agent-based and discrete-event simulation with deterministic RNG and batteries-included experiment tooling."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT License" }
+license = { text = "MIT" }
 authors = [{ name = "Simon Villani" }]
-keywords = ["simulation", "agent-based", "discrete-event", "numpy"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "numpy>=1.21",
-    "pydantic>=1.10,<3",
+    "numpy>=1.24",
+    "pydantic>=2,<3",
+    "pyyaml>=6",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7",
-    "ruff>=0.1.8",
-    "mypy>=1.7",
-    "pyyaml>=6",
-    "typer[all]>=0.9",
-    "rich>=13",
+    "ruff>=0.5",
+    "mypy>=1.8",
+    "build>=1.0",
+    "twine>=5.0",
+    "coverage>=7",
 ]
 bench = [
-    "simpy>=4 ; python_version >= '3.10'",
-    "mesa>=1.3 ; python_version >= '3.10'",
+    "simpy>=4; python_version>='3.10'",
+    "mesa>=2; python_version>='3.10'",
 ]
-all = ["fast-sim[dev,bench]"]
+viz = [
+    "rich>=13",
+    "matplotlib>=3.8",
+]
+all = ["fast-sim[dev,bench,viz]"]
 
 [project.urls]
-Homepage = "https://github.com/simonv3/fast-sim"
-Documentation = "https://github.com/simonv3/fast-sim"
-Source = "https://github.com/simonv3/fast-sim"
-Issues = "https://github.com/simonv3/fast-sim/issues"
+Homepage = "https://github.com/mmprotest/fast-sim"
+Repository = "https://github.com/mmprotest/fast-sim"
+Issues = "https://github.com/mmprotest/fast-sim/issues"
 
 [project.scripts]
-fastsim = "fast_sim.cli:app"
+fsim = "fast_sim.cli:app"
 
 [tool.hatch.version]
 path = "src/fast_sim/version.py"

--- a/src/fast_sim/cli.py
+++ b/src/fast_sim/cli.py
@@ -14,6 +14,8 @@ from .agents import queue_step, sir_step
 from .config import SimConfig
 from .random import set_seed
 
+__all__ = ["app"]
+
 app = typer.Typer(help="Vectorised micro-simulation toolkit")
 
 
@@ -60,7 +62,7 @@ def info() -> None:
     """Display package information."""
 
     extras = []
-    for extra in ("simpy", "mesa", "rich", "typer", "pyyaml"):
+    for extra in ("simpy", "mesa", "rich", "matplotlib", "pyyaml"):
         extras.append(f"{extra}:{'yes' if importlib.util.find_spec(extra) else 'no'}")
     typer.echo(json.dumps({"version": __version__, "extras": extras}, indent=2))
 


### PR DESCRIPTION
## Summary
- refresh project metadata for hatchling builds, lean dependencies, and the `fsim` console entry
- update README with install guidance, comparison table, release notes reference, and consistent CLI naming
- add release notes, CI workflow, Makefile helpers, and tighten the CLI export/extras reporting

## Testing
- pip install -e ".[dev,bench,viz]" *(fails in CI sandbox: blocked from fetching hatchling due to proxy 403)*
- pytest -q *(fails: missing numpy in offline sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ea05d20f548331a764ef8c6afc9b2b